### PR TITLE
Refactor EnumTypeReader to remove Enum constraint

### DIFF
--- a/src/Kook.Net.Commands/Readers/EnumTypeReader.cs
+++ b/src/Kook.Net.Commands/Readers/EnumTypeReader.cs
@@ -15,7 +15,7 @@ internal static class EnumTypeReader
 }
 
 internal class EnumTypeReader<T> : TypeReader
-    where T : struct, Enum
+    where T : struct
 {
     private readonly IReadOnlyDictionary<string, object> _enumsByName;
     private readonly IReadOnlyDictionary<T, object> _enumsByValue;


### PR DESCRIPTION
`EnumTypeReader` uses reflection to dynamically create instances of the generic `EnumTypeReader<T>` constructor by using the underlying primitive type of the enum, rather than the original enum type itself. This approach allows the primitive type parser from `PrimitiveParsers` to be used as the second argument to the `EnumTypeReader<T>` constructor.

#10 introduced an incorrect generic constraint `Enum` for `EnumTypeReader`, which prevents primitive types from being used as the generic parameter `T` for `EnumTypeReader<T>`, thus causing this exception.

---

Fixes #21

